### PR TITLE
Remove the .Use(), no longer necessary

### DIFF
--- a/LimitsMiddlewarwTest/Startup.cs
+++ b/LimitsMiddlewarwTest/Startup.cs
@@ -10,7 +10,7 @@ namespace LimitsMiddlewarwTest
     {
         public void Configuration(IAppBuilder app)
         {
-            app.Use().MaxUrlLength(2048); // Doesn't work, what shall I do? Missing usings? Which ones? 
+            app.MaxUrlLength(2048);
             
             app.Run(context =>
             {


### PR DESCRIPTION
The readme was out of date, sorry about that.

You should see all the extensions straight after `app.`
